### PR TITLE
[CHANGED] Adding New Objective-C keywords.

### DIFF
--- a/Syntaxes/Objective-C.tmLanguage
+++ b/Syntaxes/Objective-C.tmLanguage
@@ -248,7 +248,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(IBOutlet|IBAction|BOOL|SEL|id|unichar|IMP|Class)\b</string>
+			<string>\b(IBOutlet|IBAction|BOOL|SEL|id|unichar|IMP|Class|instancetype)\b</string>
 			<key>name</key>
 			<string>storage.type.objc</string>
 		</dict>
@@ -1440,7 +1440,7 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic)\b</string>
+							<string>\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|strong|weak)\b</string>
 							<key>name</key>
 							<string>keyword.other.property.attribute</string>
 						</dict>


### PR DESCRIPTION
Adding the new Objective-C storage type "instancetype" as well as the
property attributes "strong" and "weak".

The additional keywords have been appended to the appropriate regular expressions.
