### PR TITLE
Allow any amount of whitespace between the receiver and message

### DIFF
--- a/Syntaxes/Objective-C.tmLanguage
+++ b/Syntaxes/Objective-C.tmLanguage
@@ -509,7 +509,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(?=\w)(?&lt;=[\w\])"] )(\w+(?:(:)|(?=\])))</string>
+					<string>(?=\w)(?&lt;=[\w\]\s)"]\s)(\w+(?:(:)|(?=\])))</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Also use '\s' to account for other whitespace characters.

For example, after this change all of the `bind:` and `toObject:` args in the code snippet below should be properly highlighted.

```objc
		[self.ownerTextField   bind:NSValueBinding   toObject:_objectController withKeyPath:@"content.ownerString"   options:@{ NSContinuouslyUpdatesValueBindingOption: @YES }];
		[self.licenseTextField bind:NSValueBinding   toObject:_objectController withKeyPath:@"content.licenseString" options:@{ NSContinuouslyUpdatesValueBindingOption: @YES }];
		[self.statusTextField  bind:NSValueBinding   toObject:_objectController withKeyPath:@"content.statusString"  options:nil];
		[self.registerButton   bind:NSEnabledBinding toObject:_objectController withKeyPath:@"content.canRegister"   options:nil];
```
